### PR TITLE
Fixed missing assignment of ldapUserFullName

### DIFF
--- a/gitea-group-sync.go
+++ b/gitea-group-sync.go
@@ -160,7 +160,7 @@ func mainJob() {
 		ldapUserFullName = "sn" //change to cn if you need it
 		log.Println("By default LDAP_USER_FULL_NAME = 'sn'")
 	} else {
-		ldapUserIdentityAttribute = os.Getenv("LDAP_USER_FULL_NAME")
+		ldapUserFullName = os.Getenv("LDAP_USER_FULL_NAME")
 	}
 
 	var l *ldap.Conn


### PR DESCRIPTION
If the LDAP_USER_FULL_NAME env variable is set, its value is assigned to ldapUserIdentityAttribute. I assume it is meant to be assigned to ldapUserFullName