### PR TITLE
Added go.mod dependency management

### DIFF
--- a/gitea-group-sync.go
+++ b/gitea-group-sync.go
@@ -12,7 +12,7 @@ import (
 )
 
 import "gopkg.in/ldap.v3"
-import "gopkg.in/robfig/cron.v3"
+import "github.com/robfig/cron/v3"
 
 func AddUsersToTeam(apiKeys GiteaKeys, users []Account, team int) bool {
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/tws-inc/gitea-group-sync
+
+go 1.14
+
+require (
+	github.com/robfig/cron/v3 v3.0.1
+	gopkg.in/ldap.v3 v3.1.0
+)


### PR DESCRIPTION
With modern versions of go (I run 1.14), having dependencies in a go.mod file installs them automatically on first "go run". I used this to handle installation in my puppet deployment, but figured it might be generically useful