### PR TITLE
newer gitea doesn't always return owner as the first team

### DIFF
--- a/gitea-group-sync.go
+++ b/gitea-group-sync.go
@@ -250,7 +250,7 @@ func mainJob() {
 			log.Printf("Skip synchronization in the Owners team")
 			cfg.ApiKeys.BruteforceTokenKey = 0
 
-			for j := 1; j < len(teamList); j++ {
+			for j := 0; j < len(teamList); j++ {
 
 				// preparing request to ldap server
 				filter := fmt.Sprintf(cfg.LdapFilter, teamList[j].Name)


### PR DESCRIPTION
We cannot presume that owner will be the first team listed
so we need to run through all of the teams
After a lot of debugging, the old presumption that the Owner team,
will be the first team and therefor we can skip the first
returned team is not valid.
As a consequence if you have a LDAP group with the name Owner,
you will need to be carefull.

Signed-off-by: Toshaan Bharvani <toshaan@vantosh.com>